### PR TITLE
修复多个屏幕时 x,y溢出问题

### DIFF
--- a/src/WinFormium/Sources/Formium/Formium.Members.cs
+++ b/src/WinFormium/Sources/Formium/Formium.Members.cs
@@ -395,7 +395,7 @@ public partial class Formium : IDisposable, IWin32Window
                 _splashScreen.SendToBack();
                 _splashScreen.Visible = false;
 
-                
+
 
                 if (HostWindow != null && HostWindow.IsWindowActivated)
                 {
@@ -934,7 +934,7 @@ public partial class Formium : IDisposable, IWin32Window
         {
             ReleaseCapture();
 
-            PostMessage(WindowHandle, (uint)WindowMessage.WM_NCLBUTTONDOWN, (IntPtr)mode, Macros.MAKELPARAM((ushort)point.X, (ushort)point.Y));
+            PostMessage(WindowHandle, (uint)WindowMessage.WM_NCLBUTTONDOWN, (IntPtr)mode, (IntPtr)((point.X & 0xFFFF) | (point.Y << 16)));
 
             return true;
         }
@@ -942,7 +942,7 @@ public partial class Formium : IDisposable, IWin32Window
         {
             ReleaseCapture();
 
-            PostMessage(WindowHandle, (uint)WindowMessage.WM_NCLBUTTONDOWN, (IntPtr)HitTestValues.HTCAPTION, Macros.MAKELPARAM((ushort)point.X, (ushort)point.Y));
+            PostMessage(WindowHandle, (uint)WindowMessage.WM_NCLBUTTONDOWN, (IntPtr)HitTestValues.HTCAPTION, (IntPtr)((point.X & 0xFFFF) | (point.Y << 16)));
 
             return true;
         }


### PR DESCRIPTION
当用户为多屏幕时  y值为负值  会产生溢出问题导致无法拖动窗体